### PR TITLE
[1.x] Added lando.yml to run site in docker container

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -1,0 +1,8 @@
+name: laravel-api
+recipe: lamp
+config:
+  php: '7.4'
+  composer_version: '2.0.7'
+  via: nginx
+  database: mysql:5.7
+  xdebug: false


### PR DESCRIPTION
**What?**

Added Lando for running the site in docker container.

**Why?**

To be able to run site with php and Xdebug.

**Did you implement automated tests for this PR?**

No

**Are the tests passing on Github actions?**

Yeah

**Are the tests passing on your local machine?**

Yes

**Fun facts:**

I figured that creating lando.yml is easier than creating docker file, it makes us able to manage features easily
You have to download it from here: https://lando.dev/download/
 and install, then in the root folder of the project run "lando start"